### PR TITLE
Add Stopwatch convenience struct.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,28 @@ impl ops::Sub<Duration> for Duration {
     }
 }
 
+/// Begins measuring time in new. Call `reset` to get the cycles since last
+/// reset.
+///
+/// Convenient when measuring several different intervals back-to-back.
+pub struct Stopwatch {
+    start: Start,
+}
+
+impl Stopwatch {
+    pub fn new() -> Stopwatch {
+        Stopwatch {
+            start: Start::now(),
+        }
+    }
+
+    pub fn reset(&mut self) -> Duration {
+        let duration = Stop::now() - Start(self.start.0);
+        self.start = Start::now();
+        duration
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This adds a struct `Stopwatch` which starts recording as soon as it is
created, and may be "reset" to fetch the `Duration` since the last
reset/creation.

This is convenient in cases where `span` cannot be used and for taking
multiple adjacent measurements more succinctly.